### PR TITLE
Fixed usage text

### DIFF
--- a/src/compton.c
+++ b/src/compton.c
@@ -2245,7 +2245,7 @@ usage() {
     "-C\n"
     "  Avoid drawing shadows on dock/panel windows.\n"
     "-z\n"
-    "  Zero the part of the shadow's mask behind the window (experimental)."
+    "  Zero the part of the shadow's mask behind the window (experimental).\n"
     "-f\n"
     "  Fade windows in/out when opening/closing.\n"
     "-F\n"


### PR DESCRIPTION
Hey,

I have been using compton for some time now, it works great! I found a small error in the usage text though, the -f switch wasn't printed on a new line, which initially caused me to think -F in compton meant -f -F in xcompmgr.
Anyhow, the fix itself was two characters, but this way you can just click 'accept' ;)

Tim
