### PR TITLE
Add shadow blacklist option

### DIFF
--- a/src/compton.h
+++ b/src/compton.h
@@ -70,6 +70,8 @@ typedef struct _win {
   struct _win *next;
   Window id;
   Window client_win;
+	int has_name;
+	unsigned long name_hash;
 #if HAS_NAME_WINDOW_PIXMAP
   Pixmap pixmap;
 #endif


### PR DESCRIPTION
This adds a -B option that lets you specify window names that should not have shadows draw.  Useful for when you have things like launchers that look really back with shadows on them.  For example, I use -B synapse to avoid having the synapse window drawn with an ugly shadow.

It uses a hash of the window name to avoid doing strcmps on every draw.  There's of course a small risk of collision there, but I figure the trade-off is worth it.  The complexity of is_shadow_blacklisted grows linearly in the # of blacklisted windows (I scan the whole array for a match each time).  If you're concerned about that, I could switch it to using a proper hashtable with a bit more work, but that felt like overkill at this point.

Regards,

Nick
