### PR TITLE
Fork on all screens in a display if option -d is not provided

### DIFF
--- a/src/compton.c
+++ b/src/compton.c
@@ -5171,21 +5171,24 @@ session_init(session_t *ps_old, int argc, char **argv) {
     XSynchronize(ps->dpy, 1);
   }
 
-  // ps->scr = DefaultScreen(ps->dpy);
-  int scr_cnt = XScreenCount(ps->dpy);
-  for(;--scr_cnt;){
-      if(!fork()) break;
-  }
-  ps->scr = scr_cnt;
+  if(!ps->o.display){
+    int scr_cnt = XScreenCount(ps->dpy);
+    for(;--scr_cnt;){
+        if(!fork()) break;
+    }
+    ps->scr = scr_cnt;
 
-  char dpy_buf [] = ":0.0";
-  dpy_buf[3] = '0'+ps->scr;
-  fprintf(stderr,"Setting display %s\n",dpy_buf);
-  ps->dpy = XOpenDisplay(dpy_buf);
+    char dpy_buf [] = ":0.0";
+    dpy_buf[3] = '0'+ps->scr;
+    fprintf(stderr,"Setting display %s\n",dpy_buf);
+    ps->dpy = XOpenDisplay(dpy_buf);
 
-  if (!ps->dpy) {
-    fprintf(stderr, "Can't open display\n");
-    exit(1);
+    if (!ps->dpy) {
+      fprintf(stderr, "Can't open display\n");
+      exit(1);
+    }
+  }else{
+    ps->scr = DefaultScreen(ps->dpy);
   }
 
   ps->root = RootWindow(ps->dpy, ps->scr);


### PR DESCRIPTION
If option -d is not provided, then fork to all screens.

Code is a kind of dirty and there is a bug if the screen number a larger than 9.
