### PR TITLE
Specified drm location for FreeBSD + fixed anonymous union

### DIFF
--- a/src/c2.h
+++ b/src/c2.h
@@ -35,10 +35,10 @@ typedef struct _c2_l c2_l_t;
 /// Pointer to a condition tree.
 typedef struct {
   bool isbranch : 1;
-  //union {
+  union {
     c2_b_t *b;
     c2_l_t *l;
-  //}; // I have no idea what it was supposed to do without name.
+  };
 } c2_ptr_t;
 
 /// Initializer for c2_ptr_t.


### PR DESCRIPTION
Under FreeBSD there's no <libdrm/drm.h> but the other possibility mentioned in compton.h - <drm/drm.h> . I used **FreeBSD** define to check the system and specify another header location. There was also a strange mistake with an anonymous union which I commented out to make it work.
Leaving those matters aside compton is a great app, keep up the good work!
