### PR TITLE
compatibility with older gcc bug: unnamed union members cannot be used in init

### DIFF
--- a/src/c2.h
+++ b/src/c2.h
@@ -35,10 +35,15 @@ typedef struct _c2_l c2_l_t;
 /// Pointer to a condition tree.
 typedef struct {
   bool isbranch : 1;
-  union {
-    c2_b_t *b;
-    c2_l_t *l;
-  };
+#if _GNUC_ > 4 || ( _GNUC_ == 4 && _GNUC_MINOR_ >= 6 ) /// for compatibility with <gcc 4.2 o 4.3
+   union {
+#endif
+     c2_b_t *b;
+     c2_l_t *l;
+#if _GNUC_ > 4 || ( _GNUC_ == 4 && _GNUC_MINOR_ >= 6 )
+   };
+#endif
+
 } c2_ptr_t;
 
 /// Initializer for c2_ptr_t.


### PR DESCRIPTION
...ed in init

This solves compilation in olders gcc due a unresolved bug in <gcc-4.6 that unnamed union members cannot be used in initializer (stupid win-hat developers, always later)

_Theres no fun in a cheap software that relies on to high dependences, due high dependences need modern hardware.. **an modern hardware dont need memory savings**_: 

so **we the users that have older hardware with olders software need this** please commit thi for possibility to have compton in many distros that already not have gcc 4.6+.
