### PR TITLE
list with comma instead of slash

### DIFF
--- a/bin/compton-trans
+++ b/bin/compton-trans
@@ -26,7 +26,7 @@
 
 # "command" is a shell built-in, faster than "which"
 if test -z "$(command -v xprop)" -o -z "$(command -v xwininfo)"; then
-  echo 'Please install x11-utils/xorg-xprop/xorg-xwininfo.' >& 2
+  echo 'Please install x11-utils, xorg-xprop, xorg-xwininfo.' >& 2
   exit 1
 fi
 


### PR DESCRIPTION
Because I misinterpreted "xorg-utils/xorg-prop/xorg-xwininfo" as "section/group/package" instead of "package/package/package"

Does compton "optdepends" or "suggests" these packages?
