### PR TITLE
implement automatic cpack versioning

### DIFF
--- a/CPackConfig.cmake
+++ b/CPackConfig.cmake
@@ -9,15 +9,11 @@ endif ()
 # == Basic information ==
 set(CPACK_PACKAGE_NAME "compton")
 set(CPACK_PACKAGE_VENDOR "chjj")
-set(CPACK_PACKAGE_VERSION_MAJOR "0")
-set(CPACK_PACKAGE_VERSION_MINOR "0")
-set(CPACK_PACKAGE_VERSION_PATCH "0")
-set(CPACK_PACKAGE_VERSION "${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINOR}.${CPACK_PACKAGE_VERSION_PATCH}")
+set(CPACK_PACKAGE_VERSION "${COMPTON_VERSION}")
 set(CPACK_PACKAGE_DESCRIPTION "A lightweight X compositing window manager, fork of xcompmgr-dana.")
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "A lightweight X compositing window manager")
 set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}-${CPACK_SYSTEM_NAME}")
 set(CPACK_PACKAGE_CONTACT "nobody <devnull@example.com>")
-set(CPACK_INSTALL_COMMANDS "env PREFIX=build make install")
 
 # == Package config ==
 set(CPACK_INSTALLED_DIRECTORIES "${CMAKE_CURRENT_LIST_DIR}/build" "usr")
@@ -27,6 +23,7 @@ set(CPACK_RESOURCE_FILE_README "README.md")
 set(CPACK_STRIP_FILES 1)
 
 # == DEB package config ==
+set(CPACK_DEBIAN_PACKAGE_VERSION "${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINOR}${PATCH_VERSION}~git${GIT_DATE}")
 set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE "${CPACK_SYSTEM_NAME}")
 set(CPACK_DEBIAN_PACKAGE_SECTION "x11")
 set(CPACK_DEBIAN_PACKAGE_DEPENDS "libc6 (>= 2.15), libconfig9, libdbus-1-3 (>= 1.1.1), libgl1-mesa-glx | libgl1 | libgl1-nvidia-glx | libgl1-fglrx-glx, libpcre3 (>= 8.10), libx11-6, libxcomposite1 (>= 1:0.3-1), libxdamage1 (>= 1:1.1), libxext6, libxfixes3, libxrandr2 (>= 4.3), libxrender1, libxinerama1")

--- a/_CMakeLists.txt
+++ b/_CMakeLists.txt
@@ -1,10 +1,6 @@
 project(compton)
 cmake_minimum_required(VERSION 2.8)
 
-set(CPACK_PACKAGE_VERSION_MAJOR "0")
-set(CPACK_PACKAGE_VERSION_MINOR "0")
-set(CPACK_PACKAGE_VERSION_PATCH "0")
-
 add_subdirectory(man)
 
 set(compton_SRCS src/compton.c)
@@ -16,10 +12,30 @@ set(CMAKE_C_FLAGS_RELWITHDBGINFO "-O2 -march=native -ggdb")
 add_definitions("-Wall" "-std=c99")
 
 # == Version ==
-execute_process(COMMAND sh -c "echo -n \\\"git-$(git describe --always --dirty)-$(git log -1 --date=short --pretty=format:%cd)\\\""
+execute_process(COMMAND git describe --always --dirty
 	WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-	OUTPUT_VARIABLE COMPTON_VERSION)
-add_definitions("-DCOMPTON_VERSION=${COMPTON_VERSION}")
+	OUTPUT_VARIABLE GIT_DESCRIBE
+	OUTPUT_STRIP_TRAILING_WHITESPACE)
+execute_process(COMMAND git log -1 --date=short --pretty=format:%cd
+	WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+	OUTPUT_VARIABLE GIT_DATE
+	OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+string(REGEX REPLACE "^v([0-9]+)[.]([0-9]+)_([0-9a-zA-Z]+)-(.*)$"
+	"\\1;\\2;\\3;\\4" RESULT ${GIT_DESCRIBE})
+
+string(REGEX REPLACE "[-]" "" GIT_DATE ${GIT_DATE})
+set(COMPTON_VERSION "git-${GIT_DESCRIBE}-${GIT_DATE}")
+
+list(GET RESULT 0 CPACK_PACKAGE_VERSION_MAJOR)
+list(GET RESULT 1 CPACK_PACKAGE_VERSION_MINOR)
+list(GET RESULT 2 PATCH_VERSION)
+list(GET RESULT 3 ADDENDUM_VERSION)
+
+set(CPACK_PACKAGE_VERSION_PATCH ${PATCH_VERSION}-${ADDENDUM_VERSION}-${GIT_DATE})
+add_definitions("-DCOMPTON_VERSION=\"${COMPTON_VERSION}\"")
+
+include("CPackConfig.cmake")
 
 # == Options ==
 


### PR DESCRIPTION
Previously, DEB packages generated with CPack had useless version information, meaning that the higher-versioned official packages would try to overwrite ones from the git repository. This patch does some regexp magic to automatically version the resultant DEB.

I don't have an RPM system to test results there with, but it should either work straight out, or with trivial patching (I am not versed in RPM's versioning strictness)
