### PR TITLE
minor fix in man (1) compton

### DIFF
--- a/man/compton.1.asciidoc
+++ b/man/compton.1.asciidoc
@@ -368,7 +368,7 @@ This is the old condition format we once used. Support of this format might be r
 
 CONFIGURATION FILES
 -------------------
-compton could read from a configuration file if libconfig support is compiled in. If *--config* is not used, compton will seek for a configuration file in `$XDG_CONFIG_HOME/compton.conf` (`~/.config/compton.conf`, usually), then `~/.compton.conf`, then `compton.conf` under `$XDG_DATA_DIRS` (often `/etc/xdg/compton.conf`).
+compton could read from a configuration file if libconfig support is compiled in. If *--config* is not used, compton will seek for a configuration file in `$XDG_CONFIG_HOME/compton.conf` (`~/.config/compton.conf`, usually), then `~/.compton.conf`, then `compton.conf` under `$XDG_CONFIG_DIRS` (often `/etc/xdg/compton.conf`).
 
 compton uses general libconfig configuration file format. A sample configuration file is available as `compton.sample.conf` in the source tree. Most commandline switches each could be replaced with an option in configuration file, thus documented above. Window-type-specific settings are exposed only in configuration file and has the following format:
 


### PR DESCRIPTION
Just some minor fix in man (1) compton: section "Configuration Files" is confusing $XDG_DATA_DIRS with $XDG_CONFIG_DIRS, see [Base Directory Specification](http://standards.freedesktop.org/basedir-spec/latest/ar01s03.html).

(Strictly speaking it could have been the other way around, that is $XDG_DATA_DIRS applies and it should have been e. g. /usr/share/compton.conf. But this didn't seem exactly likely to me...)