### PR TITLE
Plug XserverRegion leak.

### DIFF
--- a/src/compton.c
+++ b/src/compton.c
@@ -2106,7 +2106,10 @@ repair_win(session_t *ps, win *w) {
 
   // Why care about damage when screen is unredirected?
   // We will force full-screen repaint on redirection.
-  if (!ps->redirected) return;
+  if (!ps->redirected) {
+    free_region(ps, &parts);
+    return;
+  }
 
   // Remove the part in the damage area that could be ignored
   if (!ps->reg_ignore_expire && w->prev_trans && w->prev_trans->reg_ignore)


### PR DESCRIPTION
I have been experiencing runaway XID usage when I leave Compton running e.g. overnight. This makes GetXIDRange slow (inside the Xorg X server), which has the side effect of making the entire X session "laggy" until Compton is restarted.

(I discovered this mainly through capturing high-level data with `oprofile`.)

I dumped cores for `Xorg` and for `compton` and took a peek: the client for whom it was allocating XIDs was, in fact, `compton`.  It wasn't hard to spot why XID allocation had slowed to a crawl; here is output from a GDB extension I threw together while troubleshooting that prints resource counts by client:

     322,548  compton
       1,126  fluxbox
         148  skippy-xd
         146  /usr/bin/X
         144  urxvtd
              ...

I also threw one together that counts resources for a particular client by `RESTYPE`:

    compton
       [qty]  [restype]
     322,076  XFixesRegion
         138  CompositeClientWindow
         131  DamageExt
          45  OTHER CLIENT
          36  PIXMAP
          35  NVIDIA GLX pixmap
          35  PICTURE
          23  ShapeClient
          21  SyncFence
           1  NVIDIA GLX context
           1  GC
           1  WINDOW
           1  NVIDIA client
           1  NVIDIA channel
           1  RandRClient
           1  CompositeClientSubwindows
           1  CompositeClientOverlay

I tried running `compton` with `--config /dev/null --backend xrender` and `--config /dev/null --backend glx`; neither of those produced the issue.  (These test runs, and the one that produced the "one unique stack" output below, were very short captures; I just started compton, switched workspaces, created/destroyed/resized/dragged a few windows, etc.)

From there it was just a lot of sweating and swearing:
  - I rebuilt `compton` with `-DDEBUG_ALLOC_REG` after extending the code that that enables to also log calls to `XFixesCreateRegionFromWindow()` (which it was missing), and to always log a backtrace.
  - I added an extra macro that just logged a given XID and a backtrace, and inserted calls to it at relevant places in the code.
  - I wrote a GDB extension that walked `compton`'s core and found every XID that it still had in one of its datastructures.
  - I wrote a script that parsed and reconciled the debugging output; with the list of XIDs that `compton` still "held", this gave me a list of leaked XIDs.
  - Then it was just a matter of looking at where the leaked XIDs were being allocated...

        1  unique alloc stacks for leaked XIDs
        21 time(s):
          win_extents < repair_win < damage_win < ev_damage_notify < ev_handle < mainloop < session_run < main

From experimenting, earlier, I suspected that the bug(s) had something to do with how `compton` was handling damage, so this made sense, and led me right to the culprit, which is the subject of this pull request.

I'm not positive, but I suspect there may be other, similar leaks, too.

Happy to share the GDB inspection tools, the extra debug logging code, or the log-analysis script, if those are things you'd be interested in.
