### PR TITLE
Make text and content opaque on a semi-transparent menu

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,8 @@ MANDIR ?= $(PREFIX)/share/man/man1
 APPDIR ?= $(PREFIX)/share/applications
 
 PACKAGES = x11 xcomposite xfixes xdamage xrender xext xrandr
-LIBS = -lm -lrt
-INCS =
+LIBS = -lm -lrt $(shell pkg-config --libs gtk+-3.0)
+INCS = $(shell pkg-config --cflags gtk+-3.0)
 
 OBJS = compton.o
 

--- a/src/common.h
+++ b/src/common.h
@@ -576,6 +576,9 @@ typedef struct _options_t {
   bool paint_on_overlay;
   /// Force painting of window content with blending.
   bool force_win_blend;
+
+  bool tommy_flag;  // Grab BG color from GTK settings and use them on the custom shader
+
   /// Resize damage for a specific number of pixels.
   int resize_damage;
   /// Whether to unredirect all windows if a full-screen opaque window

--- a/src/compton.c
+++ b/src/compton.c
@@ -11,6 +11,10 @@
 #include "compton.h"
 #include <ctype.h>
 
+// Hack: Automatically fetch the normal background and menu background colors
+#include <gtk-3.0/gtk/gtk.h>
+#include <gtk-3.0/gdk/gdk.h>
+
 // === Global constants ===
 
 /// Name strings for window types.
@@ -1436,7 +1440,7 @@ win_blur_background(session_t *ps, win *w, Picture tgt_buffer,
   const int wid = w->widthb;
   const int hei = w->heightb;
 
-  double factor_center = 1.0;
+  double factor_center = 0.0;
   // Adjust blur strength according to window opacity, to make it appear
   // better during fading
   if (!ps->o.blur_background_fixed) {
@@ -5748,6 +5752,7 @@ get_cfg(session_t *ps, int argc, char *const *argv, bool first_pass) {
     { "no-fading-destroyed-argb", no_argument, NULL, 315 },
     { "force-win-blend", no_argument, NULL, 316 },
     { "glx-fshader-win", required_argument, NULL, 317 },
+	{ "tommy-flag", no_argument, NULL, 321 },
     { "version", no_argument, NULL, 318 },
     { "no-x-selection", no_argument, NULL, 319 },
     { "no-name-pixmap", no_argument, NULL, 320 },
@@ -6018,6 +6023,66 @@ get_cfg(session_t *ps, int argc, char *const *argv, bool first_pass) {
       P_CASEBOOL(313, xrender_sync_fence);
       P_CASEBOOL(315, no_fading_destroyed_argb);
       P_CASEBOOL(316, force_win_blend);
+	  case 321: {
+        ps->o.tommy_flag = true;
+		gtk_init(NULL, NULL);
+		GdkRGBA bg_color_win, bg_color_menu;
+		GtkWidget* win = gtk_window_new(GTK_WINDOW_TOPLEVEL);
+		GtkStyleContext* ctxt = gtk_widget_get_style_context(win);
+		gtk_style_context_get_background_color(ctxt, GTK_STATE_FLAG_NORMAL, &bg_color_win);
+		gtk_widget_destroy(win);
+		GtkWidget* menu = gtk_menu_new();
+		ctxt = gtk_widget_get_style_context(menu);
+		gtk_style_context_get_background_color(ctxt, GTK_STATE_FLAG_NORMAL, &bg_color_menu);
+		gtk_widget_destroy(menu);
+		printf("I have got some colors from GTK! (%g,%g,%g) and (%g,%g,%g)\n",
+			bg_color_win.red, bg_color_win.green, bg_color_win.blue,
+			bg_color_menu.red,bg_color_menu.green,bg_color_menu.blue);
+		const int N = 2;
+		double x[2][3] = { { 0.807, 0.807, 0.807 }, { 0.953, 0.953, 0.953 } };
+		x[0][0] = bg_color_win.red; x[0][1] = bg_color_win.green; x[0][2] = bg_color_win.blue;
+		x[1][0] = bg_color_menu.red;x[1][1] = bg_color_menu.green;x[1][2] = bg_color_menu.blue;
+	    const char* part1 = 
+			"uniform float opacity;\n"
+			"uniform bool invert_color;\n"
+			"uniform sampler2D tex;\n"
+			"void main() {\n"
+			"  vec4 c = texture2D(tex, vec2(gl_TexCoord[0].x, gl_TexCoord[0].y));\n"
+			"  float eps = 0.018f;\n"
+			"  float eps1 = 0.0f;\n"
+			"  if (invert_color)\n"
+			" 	 c = vec4(vec3(c.a, c.a, c.a) - vec3(c), c.a);\n"
+			"  if(";
+
+		char tmp[200], conditions[2000];
+		int offset = 0;
+	  	for(int n=0; n<N; n++) {
+			double red = x[n][0], green = x[n][1], blue = x[n][2];
+			sprintf(tmp, "  (c.r > %g+eps1-eps && c.r < %g+eps1+eps &&\n"
+				"   c.g > %g+eps1-eps && c.g < %g+eps1+eps &&\n"
+				"   c.b > %g+eps1-eps && c.b < %g+eps1+eps)",
+				red, red, green, green, blue, blue);
+			if (n < N-1) {
+				unsigned l = strlen(tmp);
+				sprintf(tmp+l, " ||\n");
+			}
+			
+			sprintf(conditions + offset, "%s", tmp);
+			offset += strlen(tmp);
+		}
+
+	    const char* part2 = 
+			"  ) { c *= opacity; } \n"
+			"  else {  }\n"
+			"  gl_FragColor = c;\n"
+		    "}\n";
+
+		char* big = (char*)malloc(10000);
+		sprintf(big, "%s\n%s\n%s", part1, conditions, part2);
+		ps->o.glx_fshader_win_str = mstrcpy(big);
+		free(big);
+	    break;
+	  }
       case 317:
         ps->o.glx_fshader_win_str = mstrcpy(optarg);
         break;

--- a/src/opengl.c
+++ b/src/opengl.c
@@ -1558,7 +1558,7 @@ glx_render_(session_t *ps, const glx_texture_t *ptex,
 #endif
 
 #ifdef DEBUG_GLX
-  printf_dbgf("(): Draw: %d, %d, %d, %d -> %d, %d (%d, %d) z %d\n", x, y, width, height, dx, dy, ptex->width, ptex->height, z);
+  printf_dbgf("(): Draw: %d, %d, %d, %d -> %d, %d (%d, %d) z %d Opacity %g\n", x, y, width, height, dx, dy, ptex->width, ptex->height, z, opacity);
 #endif
 
   // Bind texture


### PR DESCRIPTION
Hi, Compton,

I wrote some proof-of-concept code to make the text and icons on a transparent blurred window easier to read by making them opaque.

The code adds a series of conditional statements to the shader used for rendering window contents, just like the flag `--glx-fshader-win switch` does. The shader sets the alpha value to 1 unless the pixel is of the "background color" obtained from GTK, which in many cases are equal to the background color of menus. This makes the contents on a transparent blurred window easier to read, as is illustrated below:
![Example 1](https://cloud.githubusercontent.com/assets/1406681/7616721/418d0da0-f96c-11e4-9d95-c510e492861e.png)

This is a proof of concept since it still contains many issues that have to be resolved but I do not know the solution right now.
1. Without the knowledge on which pixels belong to the content and which belong to the background, the conditionals would fail to make the content 100% opaque if the content has the same color as the background.
2. Due to the same reason, this approach does not work well with anti-aliased fonts.
3. If content below a transparent menu/dock is updated, artifacts will appear on the transparent menu/dock.

Please let me know how this could be made more useful.

Thanks!