### PR TITLE
Fix some missing trailing semicolons

### DIFF
--- a/compton.sample.conf
+++ b/compton.sample.conf
@@ -32,8 +32,8 @@ alpha-step = 0.06;
 # inactive-dim-fixed = true;
 # blur-background = true;
 # blur-background-frame = true;
-blur-kern = "3x3box"
-# blur-kern = "5,5,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1"
+blur-kern = "3x3box";
+# blur-kern = "5,5,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1";
 # blur-background-fixed = true;
 blur-background-exclude = [
 	"window_type = 'dock'",
@@ -52,7 +52,7 @@ fade-out-step = 0.03;
 fade-exclude = [ ];
 
 # Other
-backend = "xrender"
+backend = "xrender";
 mark-wmwin-focused = true;
 mark-ovredir-focused = true;
 # use-ewmh-active-win = true;


### PR DESCRIPTION
There was some missing semicolons in the sample config file that I fixed.