### PR TITLE
[WIP] configurable dim rules over dbus

### DIFF
--- a/compton.sample.conf
+++ b/compton.sample.conf
@@ -28,8 +28,6 @@ inactive-opacity = 0.8;
 frame-opacity = 0.7;
 inactive-opacity-override = false;
 alpha-step = 0.06;
-# inactive-dim = 0.2;
-# inactive-dim-fixed = true;
 # blur-background = true;
 # blur-background-frame = true;
 blur-kern = "3x3box";
@@ -41,6 +39,11 @@ blur-background-exclude = [
 	"_GTK_FRAME_EXTENTS@:c"
 ];
 # opacity-rule = [ "80:class_g = 'URxvt'" ];
+
+# Dimming
+# inactive-dim = 0.2;
+# inactive-dim-fixed = true;
+# dim-rule = [ "50:!(class_g ~= '^(URxvt|mpv|Sxiv)$' || _NET_WM_WINDOW_TYPE@:a *= 'DOCK')" ];
 
 # Fading
 fading = true;

--- a/dbus-examples/ambient-dim.sh
+++ b/dbus-examples/ambient-dim.sh
@@ -1,0 +1,171 @@
+#!/bin/bash
+
+# === Verify `compton --dbus` status ===
+
+if [ -z "`dbus-send --session --dest=org.freedesktop.DBus --type=method_call --print-reply /org/freedesktop/DBus org.freedesktop.DBus.ListNames | grep compton`" ]; then
+    echo "compton DBus interface unavailable"
+    if [ -n "`pgrep compton`" ]; then
+        echo "compton running without dbus interface"
+        #killall compton & # Causes all windows to flicker away and come back ugly.
+        #compton --dbus & # Causes all windows to flicker away and come back beautiful
+    else
+        echo "compton not running"
+    fi
+    exit 1;
+fi
+
+# === Get connection parameters ===
+
+dpy=$(echo -n "$DISPLAY" | tr -c '[:alnum:]' _)
+
+if [ -z "$dpy" ]; then
+    echo "Cannot find display."
+    exit 1;
+fi
+
+service="com.github.chjj.compton.${dpy}"
+interface="com.github.chjj.compton"
+
+compton_dbus="dbus-send --print-reply=literal --dest="${service}" / "${interface}"."
+compton_dbus_h="dbus-send --print-reply --dest="${service}" / "${interface}"."
+
+# === Try using flock ===
+
+unbright="/dev/shm/unbright.$dpy"
+if hash flock 2>/dev/null; then
+    flock="flock ${unbright}"
+else
+    echo 'flock not found, running without it'
+fi
+
+# === Get camera device ===
+if [[ -z "$1" ]] || [[ ! -c "$1" ]]; then
+    echo "usage: $0 <camera device>"
+    exit 1
+else
+    cam="$1"
+fi
+
+# === Sample parameters ===
+
+max_dim=55
+frame_ms=30
+rule='!(class_g ~= "^(URxvt|mpv|Sxiv)$" || _NET_WM_WINDOW_TYPE@:32a *= "DOCK")'
+
+# === Trap ===
+
+trap '_remove; _repaint; trap - SIGTERM && kill -- -$$' SIGINT SIGTERM EXIT
+
+_insert() {
+    ${compton_dbus}dim_rule_update string:insert string:"${1}:${rule}"
+}
+
+_remove() {
+    if [ ! -z "$last_repr" ]; then
+        ${compton_dbus}dim_rule_update string:remove string:"$last_repr" >/dev/null 2>&1
+        if [[ $? -ne 0 ]]; then
+            # Exiting during replace(). Fingers crossed we're removing the
+            # right thing
+            last_repr=$(${compton_dbus_h}opts_get string:dim-rule | \
+                grep -m1 -Po '(?<=string ").*(?=")')
+            _remove
+        fi
+    fi
+}
+
+_replace() {
+    ${compton_dbus}dim_rule_update string:replace string:"$last_repr" string:"${1}:${rule}"
+}
+
+_repaint() {
+    ${compton_dbus}repaint >/dev/null
+}
+
+replace() {
+    local new
+    if [[ -z "$last_repr" ]]; then
+        new=$(_insert $1)
+    else
+        new=$(_replace $1)
+    fi
+    last_repr=${new:3}
+    _repaint
+}
+
+_normalize() {
+    old_min=72
+    old_max=184
+    new_min=0
+    new_max=100
+    old_val=$1
+    new_val=$(( (((old_val - old_min) * (new_max - new_min)) / \
+        (old_max - old_min)) + new_min ))
+    echo $new_val
+}
+
+read_camera() {
+    while read -r brightness; do
+        $flock echo $(_normalize "$brightness") > $unbright
+    done < <(ffmpeg \
+        -hide_banner \
+        -f video4linux2 \
+        -s 640x480 \
+        -i "$cam" \
+        -filter:v "fps=fps=30, showinfo" \
+        -f null - 2>&1 \
+        | stdbuf -oL grep -Po '(?<=mean:\[)[0-9]*')
+}
+
+init_camera() {
+    # Try changing this if you don't get good results
+    v4l2-ctl -d "$cam" -c exposure_auto=3 2>/dev/null
+    v4l2-ctl -d "$cam" -c exposure_auto=1 2>/dev/null
+
+    local expo=$(v4l2-ctl -d "$cam" -l | grep -m 1 exposure_absolute | grep -Po '(?<=default=)\d+')
+    local gain=$(v4l2-ctl -d "$cam" -l | grep -m 1 gain | grep -Po '(?<=default=)\d+')
+
+    if [ ! -z "$gain" ]; then
+        v4l2-ctl -d "$cam" -c gain=0 2>/dev/null
+        v4l2-ctl -d "$cam" -c exposure_absolute=1000 2>/dev/null
+    else
+        v4l2-ctl -d "$cam" -c exposure_absolute="$expo" 2>/dev/null
+    fi
+
+}
+
+rm -f "$unbright"
+init_camera
+read_camera &
+
+last_set=0
+last_brightness=0
+while :; do
+    # TODO Implement frame-dropping
+    start_date=$(date +%s%3N)
+
+    brightness=$($flock cat "$unbright" 2>/dev/null)
+    if [[ ! -z $brightness ]]; then
+
+        new_aim=$(( $max_dim - $brightness ))
+        [[ $new_aim -lt 0 ]] && new_aim=0
+        [[ $new_aim -gt 100 ]] && new_aim=100
+
+        # +1 is poor man's way of avoiding some flicker. TODO become rich
+        if [[ $new_aim -gt $(( last_set + 1 )) ]]; then
+            last_set=$(( last_set + 1 ))
+            replace $last_set
+        elif [[ $new_aim -lt $(( $last_set - 1 )) ]]; then
+            last_set=$(( last_set - 1 ))
+            replace $last_set
+        fi
+        # echo $brightness $new_aim $last_set
+    fi
+
+    last_brightness=$brightness
+
+    end_date=$(date +%s%3N)
+    diff_date=$(( end_date - start_date ))
+    # -1 is time spent on invoking `sleep` and `printf`, kind of
+    to_sleep=$(( frame_ms - diff_date - 1 ))
+    [[ $to_sleep -gt 0 ]] && sleep $(printf "0.0%02d" $to_sleep)
+done

--- a/dbus-examples/ambient-dim.sh
+++ b/dbus-examples/ambient-dim.sh
@@ -1,22 +1,9 @@
 #!/bin/bash
 
-# === Verify `compton --dbus` status ===
-
-if [ -z "`dbus-send --session --dest=org.freedesktop.DBus --type=method_call --print-reply /org/freedesktop/DBus org.freedesktop.DBus.ListNames | grep compton`" ]; then
-    echo "compton DBus interface unavailable"
-    if [ -n "`pgrep compton`" ]; then
-        echo "compton running without dbus interface"
-        #killall compton & # Causes all windows to flicker away and come back ugly.
-        #compton --dbus & # Causes all windows to flicker away and come back beautiful
-    else
-        echo "compton not running"
-    fi
-    exit 1;
-fi
-
 # === Get connection parameters ===
 
 dpy=$(echo -n "$DISPLAY" | tr -c '[:alnum:]' _)
+unbright="/dev/shm/unbright.$dpy"
 
 if [ -z "$dpy" ]; then
     echo "Cannot find display."
@@ -29,15 +16,6 @@ interface="com.github.chjj.compton"
 compton_dbus="dbus-send --print-reply=literal --dest="${service}" / "${interface}"."
 compton_dbus_h="dbus-send --print-reply --dest="${service}" / "${interface}"."
 
-# === Try using flock ===
-
-unbright="/dev/shm/unbright.$dpy"
-if hash flock 2>/dev/null; then
-    flock="flock ${unbright}"
-else
-    echo 'flock not found, running without it'
-fi
-
 # === Get camera device ===
 if [[ -z "$1" ]] || [[ ! -c "$1" ]]; then
     echo "usage: $0 <camera device>"
@@ -48,23 +26,23 @@ fi
 
 # === Sample parameters ===
 
-max_dim=55
+max_dim=65
 frame_ms=30
-rule='!(class_g ~= "^(URxvt|mpv|Sxiv)$" || _NET_WM_WINDOW_TYPE@:32a *= "DOCK")'
+rule='!(class_g ~= "^(URxvt|mpv|Sxiv|syncterm|XTerm|stellarium|XEphem)$" || _NET_WM_WINDOW_TYPE@:32a *= "DOCK")'
 
 # === Trap ===
 
-trap '_remove; _repaint; trap - SIGTERM && kill -- -$$' SIGINT SIGTERM EXIT
+trap 'kill $(jobs -p); _remove; _repaint;' EXIT
 
 _insert() {
-    ${compton_dbus}dim_rule_update string:insert string:"${1}:${rule}"
+    ${compton_dbus}dim_rule_update string:insert string:"${1}:${rule}" 2>/dev/null
 }
 
 _remove() {
     if [ ! -z "$last_repr" ]; then
         ${compton_dbus}dim_rule_update string:remove string:"$last_repr" >/dev/null 2>&1
         if [[ $? -ne 0 ]]; then
-            # Exiting during replace(). Fingers crossed we're removing the
+            # Exiting during set_dim(). Fingers crossed we're removing the
             # right thing
             last_repr=$(${compton_dbus_h}opts_get string:dim-rule | \
                 grep -m1 -Po '(?<=string ").*(?=")')
@@ -81,7 +59,7 @@ _repaint() {
     ${compton_dbus}repaint >/dev/null
 }
 
-replace() {
+set_dim() {
     local new
     if [[ -z "$last_repr" ]]; then
         new=$(_insert $1)
@@ -89,34 +67,42 @@ replace() {
         new=$(_replace $1)
     fi
     last_repr=${new:3}
+    last_dim="$1"
     _repaint
 }
 
 _normalize() {
-    old_min=72
-    old_max=184
-    new_min=0
-    new_max=100
-    old_val=$1
+    old_min=$1
+    old_max=$2
+    new_min=$3
+    new_max=$4
+    old_val=$5
     new_val=$(( (((old_val - old_min) * (new_max - new_min)) / \
         (old_max - old_min)) + new_min ))
+    if [[ $new_min -gt $new_max ]]; then
+        [[ $new_val -gt $new_min ]] && new_val=$new_min
+        [[ $new_val -lt $new_max ]] && new_val=$new_max
+    fi
     echo $new_val
 }
 
 read_camera() {
-    while read -r brightness; do
-        $flock echo $(_normalize "$brightness") > $unbright
-    done < <(ffmpeg \
+    exec ffmpeg \
         -hide_banner \
         -f video4linux2 \
         -s 640x480 \
         -i "$cam" \
         -filter:v "fps=fps=30, showinfo" \
-        -f null - 2>&1 \
-        | stdbuf -oL grep -Po '(?<=mean:\[)[0-9]*')
+        -f null - > >(stdbuf -oL grep -Po '(?<=mean:\[)[0-9]*' | \
+        while read -r brightness; do
+            echo $(_normalize 72 184 0 100 "$brightness") > "${unbright}_"
+            mv "${unbright}_" "${unbright}"
+        done) 2>&1
 }
 
 init_camera() {
+    [[ ! -c $cam ]] && exit 1
+
     # Try changing this if you don't get good results
     v4l2-ctl -d "$cam" -c exposure_auto=3 2>/dev/null
     v4l2-ctl -d "$cam" -c exposure_auto=1 2>/dev/null
@@ -130,38 +116,55 @@ init_camera() {
     else
         v4l2-ctl -d "$cam" -c exposure_absolute="$expo" 2>/dev/null
     fi
-
 }
 
-rm -f "$unbright"
+set_ddc() {
+    local new="$1"
+    if [[ "$new" -ne "$last_ddc" ]]; then
+        if ! ps -p $ddc_pid >/dev/null 2>&1; then
+            ddccontrol -r 0x10 -w "$new" dev:/dev/i2c-2 >/dev/null 2>&1 &
+            ddc_pid=$!
+            last_ddc="$new"
+        fi
+    fi
+}
+
+dim_to() {
+    local new_aim="$1"
+    if [[ $new_aim -gt $(( last_dim + 1 )) ]]; then
+        set_dim $(( last_dim + 1 ))
+    elif [[ $new_aim -lt $(( $last_dim - 1 )) ]]; then
+        set_dim $(( last_dim - 1 ))
+    fi
+}
+
+echo > "$unbright"
 init_camera
 read_camera &
 
-last_set=0
-last_brightness=0
+last_dim=0
+last_ddc=0
 while :; do
     # TODO Implement frame-dropping
     start_date=$(date +%s%3N)
 
-    brightness=$($flock cat "$unbright" 2>/dev/null)
+    brightness=$(<"$unbright")
     if [[ ! -z $brightness ]]; then
 
-        new_aim=$(( $max_dim - $brightness ))
-        [[ $new_aim -lt 0 ]] && new_aim=0
-        [[ $new_aim -gt 100 ]] && new_aim=100
+        # DIM
+        dim_aim=$(_normalize 0 85 65 0 $brightness)
+        dim_to "$dim_aim"
 
-        # +1 is poor man's way of avoiding some flicker. TODO become rich
-        if [[ $new_aim -gt $(( last_set + 1 )) ]]; then
-            last_set=$(( last_set + 1 ))
-            replace $last_set
-        elif [[ $new_aim -lt $(( $last_set - 1 )) ]]; then
-            last_set=$(( last_set - 1 ))
-            replace $last_set
+        # DDC
+        if [[ $brightness -gt 50 ]]; then
+            new_ddc=$(_normalize 50 100 20 100 $brightness)
+        else
+            new_ddc=20
         fi
-        # echo $brightness $new_aim $last_set
-    fi
+        set_ddc $new_ddc
 
-    last_brightness=$brightness
+        # echo "$brightness -> ($new_ddc, $dim_aim)"
+    fi
 
     end_date=$(date +%s%3N)
     diff_date=$(( end_date - start_date ))

--- a/man/compton.1.asciidoc
+++ b/man/compton.1.asciidoc
@@ -234,6 +234,9 @@ May also be one of the predefined kernels: `3x3box` (default), `5x5box`, `7x7box
 *--opacity-rule* 'OPACITY':'CONDITION'::
 	Specify a list of opacity rules, in the format `PERCENT:PATTERN`, like `50:name *= "Firefox"`. compton-trans is recommended over this. Note we do not distinguish 100% and unset, and we don't make any guarantee about possible conflicts with other programs that set '_NET_WM_WINDOW_OPACITY' on frame or client windows.
 
+*--dim-rule* 'VALUE':'CONDITION'::
+	Specify a list of dim rules, in the format `VALUE:PATTERN`, like `50:!class_g *= "URxvt"`, where `VALUE` is in the 0 - 100 range (0 means no dim).
+
 *--shadow-exclude-reg* 'GEOMETRY'::
 	Specify a X geometry that describes the region in which shadow should not be painted in, such as a dock window region.  Use `--shadow-exclude-reg x10+0-0`, for example, if the 10 pixels on the bottom of the screen should not have shadows painted on.
 

--- a/src/c2.h
+++ b/src/c2.h
@@ -29,18 +29,6 @@
 
 #define C2_MAX_LEVELS 10
 
-typedef struct _c2_b c2_b_t;
-typedef struct _c2_l c2_l_t;
-
-/// Pointer to a condition tree.
-typedef struct {
-  bool isbranch : 1;
-  union {
-    c2_b_t *b;
-    c2_l_t *l;
-  };
-} c2_ptr_t;
-
 /// Initializer for c2_ptr_t.
 #define C2_PTR_INIT { \
   .isbranch = false, \
@@ -165,13 +153,6 @@ struct _c2_l {
 
 const static c2_l_t leaf_def = C2_L_INIT;
 
-/// Linked list type of conditions.
-struct _c2_lptr {
-  c2_ptr_t ptr;
-  void *data;
-  struct _c2_lptr *next;
-};
-
 /// Initializer for c2_lptr_t.
 #define C2_LPTR_INIT { \
   .ptr = C2_PTR_INIT, \
@@ -295,6 +276,9 @@ c2h_b_opcmp(c2_b_op_t op1, c2_b_op_t op2) {
   return c2h_b_opp(op1) - c2h_b_opp(op2);
 }
 
+bool
+c2_removed(c2_lptr_t **pcondlst, const uint index);
+
 static int
 c2_parse_grp(session_t *ps, const char *pattern, int offset, c2_ptr_t *presult, int level);
 
@@ -333,16 +317,14 @@ c2h_dump_str_tgt(const c2_l_t *pleaf);
 static const char *
 c2h_dump_str_type(const c2_l_t *pleaf);
 
-static void
-c2_dump_raw(c2_ptr_t p);
-
 /**
- * Wrapper of c2_dump_raw().
+ * Wrapper of c2_dump_str().
  */
 static inline void
 c2_dump(c2_ptr_t p) {
-  c2_dump_raw(p);
-  printf("\n");
+  char *c2_repr = c2_dump_str(p);
+  printf("%s\n", c2_repr);
+  free(c2_repr);
   fflush(stdout);
 }
 

--- a/src/compton.h
+++ b/src/compton.h
@@ -903,9 +903,6 @@ win_mark_client(session_t *ps, win *w, Window client);
 static void
 win_unmark_client(session_t *ps, win *w);
 
-static void
-win_recheck_client(session_t *ps, win *w);
-
 static bool
 add_win(session_t *ps, Window id, Window prev);
 

--- a/src/dbus.h
+++ b/src/dbus.h
@@ -28,6 +28,9 @@
 #define CDBUS_ERROR_BADWIN_S    "Requested window %#010lx not found."
 #define CDBUS_ERROR_BADTGT      CDBUS_ERROR_PREFIX ".bad_target"
 #define CDBUS_ERROR_BADTGT_S    "Target \"%s\" not found."
+#define CDBUS_ERROR_MISRUL      CDBUS_ERROR_PREFIX ".rule_missing"
+#define CDBUS_ERROR_MISRUL_S    "Rule of argument %d not found: \"%s\"."
+
 #define CDBUS_ERROR_FORBIDDEN   CDBUS_ERROR_PREFIX ".forbidden"
 #define CDBUS_ERROR_FORBIDDEN_S "Incorrect password, access denied."
 #define CDBUS_ERROR_CUSTOM      CDBUS_ERROR_PREFIX ".custom"
@@ -41,6 +44,12 @@ typedef uint32_t cdbus_window_t;
 typedef uint16_t cdbus_enum_t;
 #define CDBUS_TYPE_ENUM         DBUS_TYPE_UINT16
 #define CDBUS_TYPE_ENUM_STR     DBUS_TYPE_UINT16_AS_STRING
+
+typedef double cdbus_double_t;
+#define CDBUS_TYPE_DOUBLE       DBUS_TYPE_DOUBLE
+
+typedef char *cdbus_string_t;
+#define CDBUS_TYPE_STRING       DBUS_TYPE_STRING
 
 static dbus_bool_t
 cdbus_callback_add_timeout(DBusTimeout *timeout, void *data);
@@ -245,6 +254,9 @@ cdbus_process_opts_get(session_t *ps, DBusMessage *msg);
 
 static bool
 cdbus_process_opts_set(session_t *ps, DBusMessage *msg);
+
+static bool
+cdbus_process_dim_rule_update(session_t *ps, DBusMessage *msg);
 
 static bool
 cdbus_process_introspect(session_t *ps, DBusMessage *msg);


### PR DESCRIPTION
Greetings,

This patch adds on-the-fly configurable dim rules.

I wrote it because current solutions for dimming monitors below what hardware controls allow (such as `redshift`) make dark terminals unreadable.

In `dbus-examples/ambient-dim.sh` you will find an example of how I to use the new dbus interface. You may monitor its work with `dbus-send --print-reply --dest=com.github.chjj.compton._0 / com.github.chjj.compton.opts_get string:dim-rule`.

Please feel free to ask any questions or comment on any issue.

Note: Marked as WIP until I deal with a last objection valgrind has.