### PR TITLE
Remove warnings

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -2403,6 +2403,7 @@ xr_sync_(session_t *ps, Drawable d
       *pfence = XSyncCreateFence(ps->dpy, d, False);
     if (*pfence) {
       Bool triggered = False;
+      (void) triggered; /* Remove warning */
       /* if (XSyncQueryFence(ps->dpy, *pfence, &triggered) && triggered)
         XSyncResetFence(ps->dpy, *pfence); */
       // The fence may fail to be created (e.g. because of died drawable)

--- a/src/compton.c
+++ b/src/compton.c
@@ -1722,6 +1722,8 @@ win_paint_win(session_t *ps, win *w, XserverRegion reg_paint,
             reg_paint, pcache_reg);
         break;
 #endif
+      default:
+        ;
     }
   }
 
@@ -2665,29 +2667,6 @@ win_on_factor_change(session_t *ps, win *w) {
 }
 
 /**
- * Process needed window updates.
- */
-static void
-win_upd_run(session_t *ps, win *w, win_upd_t *pupd) {
-  if (pupd->shadow) {
-    win_determine_shadow(ps, w);
-    pupd->shadow = false;
-  }
-  if (pupd->fade) {
-    win_determine_fade(ps, w);
-    pupd->fade = false;
-  }
-  if (pupd->invert_color) {
-    win_determine_invert_color(ps, w);
-    pupd->invert_color = false;
-  }
-  if (pupd->focus) {
-    win_update_focused(ps, w);
-    pupd->focus = false;
-  }
-}
-
-/**
  * Update cache data in struct _win that depends on window size.
  */
 static void
@@ -3440,8 +3419,6 @@ wid_get_prop_window(session_t *ps, Window wid, Atom aprop) {
  */
 static void
 win_update_focused(session_t *ps, win *w) {
-  bool focused_old = w->focused;
-
   if (UNSET != w->focused_force) {
     w->focused = w->focused_force;
   }
@@ -6599,6 +6576,8 @@ init_filters(session_t *ps) {
             return false;
         }
 #endif
+      default:
+        ;
     }
   }
 

--- a/src/compton.h
+++ b/src/compton.h
@@ -733,6 +733,8 @@ set_tgt_clip(session_t *ps, XserverRegion reg, const reg_data_t *pcache_reg) {
       glx_set_clip(ps, reg, pcache_reg);
       break;
 #endif
+    default:
+      ;
   }
 }
 
@@ -884,9 +886,6 @@ win_on_wtype_change(session_t *ps, win *w);
 
 static void
 win_on_factor_change(session_t *ps, win *w);
-
-static void
-win_upd_run(session_t *ps, win *w, win_upd_t *pupd);
 
 static void
 calc_win_size(session_t *ps, win *w);


### PR DESCRIPTION
- struct that don't check all values
- unused variables in some configurations
- unused function (removed)