### PR TITLE
fix some undefined behavior

### DIFF
--- a/src/c2.c
+++ b/src/c2.c
@@ -596,9 +596,10 @@ c2_parse_pattern(session_t *ps, const char *pattern, int offset, c2_ptr_t *presu
                         char *pstr = NULL;
                         long val = strtol(tstr, &pstr,
                             ('o' == pattern[offset] ? 8: 16));
-                        free(tstr);
-                        if (pstr != &tstr[2] || val <= 0)
+                        if (pstr != &tstr[2] || val <= 0){
                           c2_error("Invalid octal/hex escape sequence.");
+                        }
+                        free(tstr);
                         assert(val < 256 && val >= 0);
                         *(ptptnstr++) = val;
                         offset += 2;

--- a/src/common.h
+++ b/src/common.h
@@ -1816,11 +1816,11 @@ fds_drop(session_t *ps, int fd, short events) {
   fd_set * key = NULL; \
   if (ps->key) { \
     key = malloc(sizeof(fd_set)); \
-    memcpy(key, ps->key, sizeof(fd_set)); \
     if (!key) { \
       fprintf(stderr, "Failed to allocate memory for copying select() fdset.\n"); \
       exit(1); \
     } \
+    memcpy(key, ps->key, sizeof(fd_set)); \
   } \
 
 /**

--- a/src/compton.c
+++ b/src/compton.c
@@ -7136,6 +7136,9 @@ session_init(session_t *ps_old, int argc, char **argv) {
 
   // Allocate a session and copy default values into it
   session_t *ps = malloc(sizeof(session_t));
+  if(!ps){
+    printf_errfq(1, "(): Can't allocate session.");
+  }
   memcpy(ps, &s_def, sizeof(session_t));
   ps_g = ps;
   ps->ignore_tail = &ps->ignore_head;

--- a/src/opengl.c
+++ b/src/opengl.c
@@ -752,6 +752,10 @@ glx_bind_pixmap(session_t *ps, glx_texture_t **pptex, Pixmap pixmap,
     };
 
     ptex = malloc(sizeof(glx_texture_t));
+    if(!ptex){
+      printf_errf("Can't allocate memory. This can't work.");
+      return false;
+    }
     allocchk(ptex);
     memcpy(ptex, &GLX_TEX_DEF, sizeof(glx_texture_t));
     *pptex = ptex;


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. 
Errors:
    compton/src/c2.c	600	err	V774 The 'tstr' pointer was used after the memory was released.
Warning: 
    compton/src/common.h	1835	warn	V575 The potential null pointer is passed into 'memcpy' function. Inspect the first argument.
    compton/src/common.h	1836	warn	V575 The potential null pointer is passed into 'memcpy' function. Inspect the first argument.
    compton/src/common.h	1837	warn	V575 The potential null pointer is passed into 'memcpy' function. Inspect the first argument.
    compton/src/compton.c	7139	warn	V575 The potential null pointer is passed into 'memcpy' function. Inspect the first argument.