### PR TITLE
Fix 100% opaticy rule with inactive-opacity

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -1170,6 +1170,8 @@ typedef struct _win {
   opacity_t opacity_prop_client;
   /// Last window opacity value we set.
   opacity_t opacity_set;
+  /// Opacity disabled - use opacity-rule 100 will set it to true
+  bool opacity_disabled;
 
   // Fading-related members
   /// Do not fade if it's false. Change on window type change.

--- a/src/compton.c
+++ b/src/compton.c
@@ -2368,6 +2368,8 @@ calc_opacity(session_t *ps, win *w) {
 
   if (w->destroyed || IsViewable != w->a.map_state)
     opacity = 0;
+  else if (w->opacity_disabled)
+    w->opacity_tgt = OPAQUE; 
   else {
     // Try obeying opacity property and window type opacity firstly
     if (OPAQUE == (opacity = w->opacity_prop)
@@ -2377,7 +2379,8 @@ calc_opacity(session_t *ps, win *w) {
 
     // Respect inactive_opacity in some cases
     if (ps->o.inactive_opacity && false == w->focused
-        && (OPAQUE == opacity || ps->o.inactive_opacity_override)) {
+        && (OPAQUE == opacity || ps->o.inactive_opacity_override)
+	&& false == w->opacity_disabled) {
       opacity = ps->o.inactive_opacity;
     }
 
@@ -2613,6 +2616,11 @@ win_update_opacity_rule(session_t *ps, win *w) {
   void *val = NULL;
   if (c2_matchd(ps, w, ps->o.opacity_rules, &w->cache_oparule, &val))
     opacity = ((double) (long) val) / 100.0 * OPAQUE;
+
+  if ((long) val == (long) 100)
+    w->opacity_disabled = true;
+  else
+    w->opacity_disabled = false;
 
   if (opacity == w->opacity_set)
     return;


### PR DESCRIPTION
When inactive-opacity is enabled, you can override the opacity by using opacity-rule.

By default, all windows have 100 opacity and, if it is still at 100,
inactive-opacity will be applied when the window loses focus. This
patch adds a new bool opacity_disabled to win struct and verify this
variable before deciding if it should be excluded from inactive-opacity

Fix 99% transparency problems on  chjj/compton#450 chjj/compton#433
chjj/compton#403 chjj/compton#367 chjj/compton#260 chjj/compton#182
chjj/compton#158