### PR TITLE
docs: fix simple typo, proprties -> properties

### DIFF
--- a/src/compton.c
+++ b/src/compton.c
@@ -4187,7 +4187,7 @@ ev_property_notify(session_t *ps, XPropertyEvent *ev) {
       }
     }
 
-    // Unconcerned about any other proprties on root window
+    // Unconcerned about any other properties on root window
     return;
   }
 


### PR DESCRIPTION
There is a small typo in src/compton.c.

Should read `properties` rather than `proprties`.

